### PR TITLE
Refactor: asset thumbnail adaptive height

### DIFF
--- a/packages/ui/src/AssetItem/AssetThumbnail.tsx
+++ b/packages/ui/src/AssetItem/AssetThumbnail.tsx
@@ -77,9 +77,8 @@ const AssetThumbnailRoot = styled(Flex, {
   '& img': {
     display: 'block',
     objectFit: 'cover',
-    width: '60%',
-    maxWidth: '100%',
-    maxHeight: '100%',
+    maxWidth: '75%',
+    maxHeight: '75%',
     transform: 'scale(1)',
     transition: 'transform 0.16s ease-in-out',
   },

--- a/packages/ui/src/AssetItem/AssetThumbnail.tsx
+++ b/packages/ui/src/AssetItem/AssetThumbnail.tsx
@@ -77,8 +77,8 @@ const AssetThumbnailRoot = styled(Flex, {
   '& img': {
     display: 'block',
     objectFit: 'cover',
-    maxWidth: '75%',
-    maxHeight: '75%',
+    maxWidth: '60%',
+    maxHeight: '60%',
     transform: 'scale(1)',
     transition: 'transform 0.16s ease-in-out',
   },


### PR DESCRIPTION
before:
<img width="363" alt="image" src="https://github.com/user-attachments/assets/e689c11c-2ca0-4dc3-8b16-32f405bdf8dc" />
（The image icon is taller than the canvas icon）

after:
<img width="399" alt="image" src="https://github.com/user-attachments/assets/0ab755f7-9ae0-433a-aa4e-b47fe61c5345" />
